### PR TITLE
Fix for format prop not applied on change event (date picker)

### DIFF
--- a/src/components/date-input.vue
+++ b/src/components/date-input.vue
@@ -31,8 +31,8 @@
 
                 const vm = this
                 this.$el.onchange = function () {
-                    if (this.format)
-                        vm.$emit('input', picker.get('select', this.format))
+                    if (vm.format)
+                        vm.$emit('input', picker.get('select', vm.format))
                     else
                         vm.$emit('input', picker.get('select', 'd mmmm, yyyy'))
                 }


### PR DESCRIPTION
Format property was not applied to onchange event causing the date format being hardcoded default `d mmmm, yyyy`

Changed to `vm.format` to get format prop instead of `this.format` because here `this` is pulling the form input element, not the desired vue component property.

PS: format prop should be added to the documentation because it might be very helpful.