### PR TITLE
Added text-field property to select component

### DIFF
--- a/src/components/date-input.vue
+++ b/src/components/date-input.vue
@@ -31,8 +31,8 @@
 
                 const vm = this
                 this.$el.onchange = function () {
-                    if (this.format)
-                        vm.$emit('input', picker.get('select', this.format))
+                    if (vm.format)
+                        vm.$emit('input', picker.get('select', vm.format))
                     else
                         vm.$emit('input', picker.get('select', 'd mmmm, yyyy'))
                 }

--- a/src/components/select.vue
+++ b/src/components/select.vue
@@ -5,7 +5,7 @@
         >{{ selectText }}</option>
         <option v-for="item in items"
                 v-bind:value="item.id"
-                v-text="item.text"
+                v-text="item[textField]"
         ></option>
         <slot></slot>
     </select>
@@ -31,6 +31,10 @@
             value: {
                 default: null,
                 required: false
+            },
+            textField: {
+                type: String,
+                default: 'text'
             }
         },
 


### PR DESCRIPTION
Added `text-field` (`textField`) property to select component to dynamically assign `v-text` key for rendering select options in select component. Allows for more flexibility when populating select options with existing ajax calls.